### PR TITLE
Handling some file paths when there is a space in it

### DIFF
--- a/src/Traits/LaravelConfigFile.php
+++ b/src/Traits/LaravelConfigFile.php
@@ -108,7 +108,7 @@ trait LaravelConfigFile
     private function addTextIntoMountPoint($mountpoint, $textToAdd)
     {
         passthru(
-            'sed -i \'s/.*'.$mountpoint.'.*/ \ \ \ \ \ \ \ '.$this->scapeSingleQuotes(preg_quote($textToAdd)).',\n \ \ \ \ \ \ \ '.$mountpoint.'/\' '.$this->laravel_config_file, $error);
+            'sed -i \'s/.*'.$mountpoint.'.*/ \ \ \ \ \ \ \ '.$this->scapeSingleQuotes(preg_quote($textToAdd)).',\n \ \ \ \ \ \ \ '.$mountpoint.'/\' '.str_replace(" ", "\ ", $this->laravel_config_file), $error);
 
         return $error;
     }
@@ -126,10 +126,10 @@ trait LaravelConfigFile
         if ($outputFile != null) {
             passthru(
                 'sed -e \'/'.$mountpoint.'/r'.$fileToInsert.'\' '.
-                    $this->laravel_services_file.' > '.$outputFile, $error);
+                    str_replace(" ", "\ ", $this->laravel_services_file).' > '.$outputFile, $error);
         } else {
             passthru(
-                'sed -i \'/'.$mountpoint.'/r'.$fileToInsert.'\' '.$this->laravel_services_file, $error);
+                'sed -i \'/'.$mountpoint.'/r'.$fileToInsert.'\' '.str_replace(" ", "\ ", $this->laravel_services_file), $error);
         }
 
         return $error;
@@ -214,8 +214,8 @@ trait LaravelConfigFile
      */
     protected function installConfigFileWithBash()
     {
-        passthru(__DIR__.'/../bash_scripts/iluminar.sh '.$this->laravel_config_file.' '
-            .$this->laravel_services_file);
+        passthru(str_replace(" ", "\ ", __DIR__).'/../bash_scripts/iluminar.sh '. str_replace(" ", "\ ", $this->laravel_config_file) .' '
+            . str_replace(" ", "\ ", $this->laravel_services_file));
     }
 
     /**

--- a/src/bash_scripts/iluminar.sh
+++ b/src/bash_scripts/iluminar.sh
@@ -7,9 +7,9 @@ fi
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-. ${DIR}/llum.sh
+. "${DIR}"/llum.sh
 
 
-iluminar $1
+iluminar "$1"
 
-iluminarServices $2
+iluminarServices "$2"

--- a/src/bash_scripts/llum.sh
+++ b/src/bash_scripts/llum.sh
@@ -7,19 +7,19 @@ TEXT_TO_SEARCH_PACKAGE_SERVICE_PROVIDERS="Package Service Providers..."
 
 function searchLineToInsertPackageServiceProviders()
 {
-    local line=$(sed -n "/$TEXT_TO_SEARCH_PACKAGE_SERVICE_PROVIDERS/=" $1);
+    local line=$(sed -n "/$TEXT_TO_SEARCH_PACKAGE_SERVICE_PROVIDERS/=" "$1");
     echo "$(($line -1))"
 }
 
 function searchLineToInsertNewValueToEndOfPHPArray()
 {
-    local line=$(sed -n "/'$1'/=" $2);
-    nline=$(sed -n ${line},\$p $2 | sed -n "/]/{=;q};");
+    local line=$(sed -n "/'$1'/=" "$2");
+    nline=$(sed -n ${line},\$p "$2" | sed -n "/]/{=;q};");
     echo "$(($line + $nline -1))"
 }
 
 function searchLineOfLastCommandInFile(){
-    local line=$(sed -n "/],/=" $1 | tail -1);
+    local line=$(sed -n "/],/=" "$1" | tail -1);
     echo "$(($line + 1))"
 }
 
@@ -29,7 +29,7 @@ function insertLineIntoFile(){
 
 function abortIfLlumIsAlreadyInstalled(){
     needle=${2:-#llum_providers}
-    if grep -Fq "$needle" $1
+    if grep -Fq "$needle" "$1"
     then
         echo "Llum is already installed. Skipping...";
         exit
@@ -37,7 +37,7 @@ function abortIfLlumIsAlreadyInstalled(){
 }
 
 function abortIfFileDoesNotExists(){
-    if [ ! -f $1 ]; then
+    if [ ! -f "$1" ]; then
         echo "File $1 not found!"
         exit 1;
     fi


### PR DESCRIPTION
## Description

I made llum able to deal with paths that contain spaces. My changes can be summarized as bellow:
- I replaced the " " (space character) for "\ " in the function `passthru` in some PHP files for the paths; and
- I added double quotes to the bash scripts that deals with paths in order to deal with them correctly.

## Motivation and context

Users that have llum installed in a folder that has a space in the full path could not run llum because it was generating errors as the path is "broken" because of the space. This issue was opened at https://github.com/acacha/adminlte-laravel/issues/225. A pull request for [AdminLTE Laravel Installer](https://github.com/acacha/adminlte-laravel-installer) is proposed as part of the solution for the problem: https://github.com/acacha/adminlte-laravel-installer/pull/13.

## How has this been tested?

This is what I did:
1. I created a virtual machine with Ubuntu 16.04 using vagrant and created an user with the home folder `/home/cleber alcantara/`.
1. I installed composer, laravel and adminlte-installer.
1. I created a laravel project and tried to run `adminlte-laravel install`. This last command generated the errors described in the issue mentioned in the previous section. 
1. I edited the files in the `/home/cleber alcantara/.composer/vendor/acacha/adminlte-laravel-installer` and `/home/cleber alcantara/.composer/vendor/acacha/llum` in order to fix the problems. 
1. I created a project using laravel and ran `adminlte-laravel install` successfully. 
1. I tested the new projects in my browser and they worked as expected.
1. I renamed home directory to `/home/cleber` and proceeded the same way, creating projects using laravel and running `adminlte-laravel install`. No errors occurred, which means my changes did not affect the "normal cases" when the paths for llum and adminlte-laravel do not have spaces.
## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
