### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Running php artisan serve --port=8002
 Opening http://localhost:8002 with default browser
  ```
  
-##migrate
+## migrate
 
 Runs php artisan migrate
 
@@ -211,7 +211,7 @@ Runs php artisan migrate
 llum migrate
 ```
 
-#Packagist
+# Packagist
 
 https://packagist.org/packages/acacha/admin
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
